### PR TITLE
Print Out Errors Rather than Displaying Message Boxes in CLI Mode

### DIFF
--- a/Source/Compiler.cpp
+++ b/Source/Compiler.cpp
@@ -200,7 +200,7 @@ bool CCompiler::OpenFile(LPCTSTR lpszFileName, CFile &file) const
 		CString strFormatted;
 		ex.GetErrorMessage(szCause, 255);
 		AfxFormatString1(strFormatted, IDS_OPEN_FILE_ERROR, szCause);
-		AfxMessageBox(strFormatted, MB_OK | MB_ICONERROR);
+		theApp.DisplayMessage(strFormatted, MB_OK | MB_ICONERROR);
 		return false;
 	}
 
@@ -221,7 +221,7 @@ void CCompiler::ExportNSF(LPCTSTR lpszFileName, int MachineType)
 
 	if (nsfewarning) {
 		Print(_T("Warning: NSFe optional metadata will not be exported in this format!\n"));
-		AfxMessageBox(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
+		theApp.DisplayMessage(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
 	}
 
 	// Build the music data
@@ -858,12 +858,12 @@ void CCompiler::ExportNES(LPCTSTR lpszFileName, bool EnablePAL)
 
 	if (nsfewarning) {
 		Print(_T("Warning: NSFe optional metadata will not be exported in this format!\n"));
-		AfxMessageBox(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
+		theApp.DisplayMessage(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
 	}
 
 	if (m_pDocument->GetExpansionChip() != SNDCHIP_NONE) {
 		Print(_T("Error: Expansion chips not supported.\n"));
-		AfxMessageBox(_T("Expansion chips are currently not supported when exporting to .NES!"), 0, 0);
+		theApp.DisplayMessage(_T("Expansion chips are currently not supported when exporting to .NES!"), 0, 0);
 		Cleanup();
 		return;
 	}
@@ -883,7 +883,7 @@ void CCompiler::ExportNES(LPCTSTR lpszFileName, bool EnablePAL)
 	if (m_bBankSwitched) {
 		// Abort if larger than 32kb
 		Print(_T("Error: Song is too large, aborted.\n"));
-		AfxMessageBox(_T("Song is too big to fit into 32kB!"), 0, 0);
+		theApp.DisplayMessage(_T("Song is too big to fit into 32kB!"), 0, 0);
 		Cleanup();
 		return;
 	}
@@ -949,7 +949,7 @@ void CCompiler::ExportBIN(LPCTSTR lpszBIN_File, LPCTSTR lpszDPCM_File, int Machi
 
 	if (nsfewarning) {
 		Print(_T("Warning: NSFe optional metadata will not be exported in this format!\n"));
-		AfxMessageBox(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
+		theApp.DisplayMessage(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
 	}
 
 	// Build the music data
@@ -1125,12 +1125,12 @@ void CCompiler::ExportPRG(LPCTSTR lpszFileName, bool EnablePAL)
 
 	if (nsfewarning) {
 		Print(_T("Warning: NSFe optional metadata will not be exported in this format!\n"));
-		AfxMessageBox(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
+		theApp.DisplayMessage(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
 	}
 
 	if (m_pDocument->GetExpansionChip() != SNDCHIP_NONE) {
 		Print(_T("Expansion chips not supported.\n"));
-		AfxMessageBox(_T("Error: Expansion chips is currently not supported when exporting to PRG!"), 0, 0);
+		theApp.DisplayMessage(_T("Error: Expansion chips is currently not supported when exporting to PRG!"), 0, 0);
 		Cleanup();
 		return;
 	}
@@ -1150,7 +1150,7 @@ void CCompiler::ExportPRG(LPCTSTR lpszFileName, bool EnablePAL)
 	if (m_bBankSwitched) {
 		// Abort if larger than 32kb
 		Print(_T("Song is too big, aborted.\n"));
-		AfxMessageBox(_T("Error: Song is too big to fit!"), 0, 0);
+		theApp.DisplayMessage(_T("Error: Song is too big to fit!"), 0, 0);
 		Cleanup();
 		return;
 	}
@@ -1211,7 +1211,7 @@ void CCompiler::ExportASM(LPCTSTR lpszFileName, int MachineType, bool ExtraData)
 
 	if (nsfewarning) {
 		Print(_T("Warning: NSFe optional metadata will not be exported in this format!\n"));
-		AfxMessageBox(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
+		theApp.DisplayMessage(_T("NSFe optional metadata will not be exported in this format!"), 0, 0);
 	}
 
 	// Build the music data

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -718,6 +718,8 @@ void CFamiTrackerApp::EnableMFCPrint()
 		}
 
 		puts(APP_NAME_VERSION);
+
+		m_bIsCLI = true;
 	}
 }
 
@@ -828,6 +830,25 @@ void CFamiTrackerApp::OnFileOpen()
 
 	if (pFrameWnd)
 		pFrameWnd->SetMessageText(IDS_LOADING_DONE);
+}
+
+void CFamiTrackerApp::DisplayMessage(LPCTSTR lpszText, UINT nType, UINT nIDHelp)
+{
+	if (m_bIsCLI)
+		_putts(lpszText);
+	else
+		AfxMessageBox(lpszText, nType, nIDHelp);
+}
+
+void CFamiTrackerApp::DisplayMessage(UINT nIDPrompt, UINT nType, UINT nIDHelp)
+{
+	if (m_bIsCLI) {
+		CString strFormatted;
+		AfxFormatString1(strFormatted, nIDPrompt, "");
+		_putts(strFormatted);
+	}
+	else
+		AfxMessageBox(nIDPrompt, nType, nIDHelp);
 }
 
 // Used to display a messagebox on the main thread

--- a/Source/FamiTracker.h
+++ b/Source/FamiTracker.h
@@ -120,6 +120,8 @@ public:
 	bool			IsThemeActive() const;
 	void			RefreshFrameEditor();
 	void			EnableMFCPrint();
+	void			DisplayMessage(LPCTSTR lpszText, UINT nType = 0, UINT nIDHelp = 0);
+	void			DisplayMessage(UINT nIDPrompt, UINT nType = 0, UINT nIDHelp = 0);
 	void			ThreadDisplayMessage(LPCTSTR lpszText, UINT nType = 0, UINT nIDHelp = 0);
 	void			ThreadDisplayMessage(UINT nIDPrompt, UINT nType = 0, UINT nIDHelp = 0);
 
@@ -173,6 +175,7 @@ private:
 
 	bool m_CoInitialized;
 	bool			m_bRunning = false;		// // //
+	bool			m_bIsCLI = false;
 	bool			m_bThemeActive;
 
 	bool			m_bVersionReady;

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -713,7 +713,7 @@ BOOL CFamiTrackerDoc::SaveDocument(LPCTSTR lpszPathName) const
 		CString strFormatted;
 		ex.GetErrorMessage(szCause, 255);
 		AfxFormatString1(strFormatted, IDS_SAVE_FILE_ERROR, szCause);
-		AfxMessageBox(strFormatted, MB_OK | MB_ICONERROR);
+		theApp.DisplayMessage(strFormatted, MB_OK | MB_ICONERROR);
 		m_pCurrentDocument = nullptr;		// // //
 		return FALSE;
 	}
@@ -727,7 +727,7 @@ BOOL CFamiTrackerDoc::SaveDocument(LPCTSTR lpszPathName) const
 		// Display error
 		CString	ErrorMsg;
 		ErrorMsg.LoadString(IDS_SAVE_ERROR);
-		AfxMessageBox(ErrorMsg, MB_OK | MB_ICONERROR);
+		theApp.DisplayMessage(ErrorMsg, MB_OK | MB_ICONERROR);
 		m_pCurrentDocument = nullptr;		// // //
 		return FALSE;
 	}
@@ -752,7 +752,7 @@ BOOL CFamiTrackerDoc::SaveDocument(LPCTSTR lpszPathName) const
 		strFormatted += ErrorMsg;
 		
 		AfxFormatString1(strFormatted, IDS_SAVE_FILE_ERROR, lpMsgBuf);
-		AfxMessageBox(strFormatted, MB_OK | MB_ICONERROR);
+		theApp.DisplayMessage(strFormatted, MB_OK | MB_ICONERROR);
 		
 		m_pCurrentDocument = nullptr;
 		return FALSE;
@@ -786,7 +786,7 @@ BOOL CFamiTrackerDoc::SaveDocument(LPCTSTR lpszPathName) const
 		str.Format("%d", err);
 		strFormatted += str;
 
-		AfxMessageBox(strFormatted, MB_OK | MB_ICONERROR);
+		theApp.DisplayMessage(strFormatted, MB_OK | MB_ICONERROR);
 		LocalFree(lpMsgBuf);
 
 		// FIXME: Remove temp file. May or may not be what you want.
@@ -1418,7 +1418,7 @@ BOOL CFamiTrackerDoc::OpenDocument(LPCTSTR lpszPathName)
 		ex.GetErrorMessage(szCause, sizeof(szCause));
 		strFormatted = _T("Could not open file.\n\n");
 		strFormatted += szCause;
-		AfxMessageBox(strFormatted);
+		theApp.DisplayMessage(strFormatted);
 		//OnNewDocument();
 		return FALSE;
 	}
@@ -1462,7 +1462,7 @@ BOOL CFamiTrackerDoc::OpenDocument(LPCTSTR lpszPathName)
 		}
 	}
 	catch (CModuleException *e) {
-		AfxMessageBox(e->GetErrorString().c_str(), MB_ICONERROR);
+		theApp.DisplayMessage(e->GetErrorString().c_str(), MB_ICONERROR);
 		m_pCurrentDocument = nullptr;		// // //
 		delete e;
 		return FALSE;
@@ -1743,7 +1743,7 @@ BOOL CFamiTrackerDoc::OpenDocumentNew(CDocumentFile &DocumentFile)
 		// This shouldn't show up in release (debug only)
 #ifdef _DEBUG
 			if (++_msgs_ < 5)
-				AfxMessageBox(_T("Unknown file block!"));
+				theApp.DisplayMessage(_T("Unknown file block!"));
 #endif
 			if (DocumentFile.IsFileIncomplete())
 				ErrorFlag = true;
@@ -1753,7 +1753,7 @@ BOOL CFamiTrackerDoc::OpenDocumentNew(CDocumentFile &DocumentFile)
 	DocumentFile.Close();
 
 	if (ErrorFlag) {
-		AfxMessageBox(IDS_FILE_LOAD_ERROR, MB_ICONERROR);
+		theApp.DisplayMessage(IDS_FILE_LOAD_ERROR, MB_ICONERROR);
 		DeleteContents();
 		return FALSE;
 	}
@@ -2745,7 +2745,7 @@ void CFamiTrackerDoc::ReadBlock_JSON(CDocumentFile* pDocFile, const int Version)
 
 	if (!unknowns.empty()) {
 		auto err = "Warning: unknown JSON data (will be discarded upon saving!):\n" + unknowns.dump();
-		AfxMessageBox(conv::to_t(std::move(err)).c_str(), MB_ICONWARNING);
+		theApp.DisplayMessage(conv::to_t(std::move(err)).c_str(), MB_ICONWARNING);
 	}
 
 	// If unchanged, stop loading data
@@ -2838,7 +2838,7 @@ bool CFamiTrackerDoc::ImportInstruments(CFamiTrackerDoc *pImported, int *pInstTa
 	// Check instrument count
 	if (GetInstrumentCount() + pImported->GetInstrumentCount() > MAX_INSTRUMENTS) {
 		// Out of instrument slots
-		AfxMessageBox(IDS_IMPORT_INSTRUMENT_COUNT, MB_ICONERROR);
+		theApp.DisplayMessage(IDS_IMPORT_INSTRUMENT_COUNT, MB_ICONERROR);
 		return false;
 	}
 
@@ -2849,7 +2849,7 @@ bool CFamiTrackerDoc::ImportInstruments(CFamiTrackerDoc *pImported, int *pInstTa
 	// Copy sequences
 	for (size_t i = 0; i < sizeof(chip); i++) for (int t = 0; t < SEQ_COUNT; ++t) {
 		if (GetSequenceCount(inst[i], t) + pImported->GetSequenceCount(inst[i], t) > MAX_SEQUENCES) {		// // //
-			AfxMessageBox(IDS_IMPORT_SEQUENCE_COUNT, MB_ICONERROR);
+			theApp.DisplayMessage(IDS_IMPORT_SEQUENCE_COUNT, MB_ICONERROR);
 			return false;
 		}
 		for (unsigned int s = 0; s < MAX_SEQUENCES; ++s) if (pImported->GetSequenceItemCount(inst[i], s, t) > 0) {
@@ -2886,7 +2886,7 @@ bool CFamiTrackerDoc::ImportInstruments(CFamiTrackerDoc *pImported, int *pInstTa
 
 	if (bOutOfSampleSpace) {
 		// Out of sample space
-		AfxMessageBox(IDS_IMPORT_SAMPLE_SLOTS, MB_ICONEXCLAMATION);
+		theApp.DisplayMessage(IDS_IMPORT_SAMPLE_SLOTS, MB_ICONEXCLAMATION);
 		return false;
 	}
 
@@ -2941,7 +2941,7 @@ bool CFamiTrackerDoc::ImportGrooves(CFamiTrackerDoc *pImported, int *pGrooveMap)
 		if (pImported->GetGroove(i) != NULL) {
 			while (GetGroove(Index) != NULL) Index++;
 			if (Index >= MAX_GROOVE) {
-				AfxMessageBox(IDS_IMPORT_GROOVE_SLOTS, MB_ICONEXCLAMATION);
+				theApp.DisplayMessage(IDS_IMPORT_GROOVE_SLOTS, MB_ICONEXCLAMATION);
 				return false;
 			}
 			pGrooveMap[i] = Index;
@@ -3312,7 +3312,7 @@ void CFamiTrackerDoc::SaveInstrument(unsigned int Index, CString FileName) const
 	ASSERT(pInstrument);
 	
 	if (file.m_hFile == CFile::hFileNull) {
-		AfxMessageBox(IDS_FILE_OPEN_ERROR, MB_ICONERROR);
+		theApp.DisplayMessage(IDS_FILE_OPEN_ERROR, MB_ICONERROR);
 		return;
 	}
 
@@ -3390,13 +3390,13 @@ int CFamiTrackerDoc::LoadInstrument(CString FileName)
 	}
 	catch (int ID) {		// // // TODO: put all error messages into string table then add exception ctor
 		m_csDocumentLock.Unlock();
-		AfxMessageBox(ID, MB_ICONERROR);
+		theApp.DisplayMessage(ID, MB_ICONERROR);
 		return INVALID_INSTRUMENT;
 	}
 	catch (CModuleException *e) {
 		m_csDocumentLock.Unlock();
 		m_pInstrumentManager->RemoveInstrument(Slot);
-		AfxMessageBox(e->GetErrorString().c_str(), MB_ICONERROR);
+		theApp.DisplayMessage(e->GetErrorString().c_str(), MB_ICONERROR);
 		delete e;
 		return INVALID_INSTRUMENT;
 	}

--- a/Source/TextExporter.cpp
+++ b/Source/TextExporter.cpp
@@ -1238,12 +1238,14 @@ const CString& CTextExport::ImportFile(LPCTSTR FileName, CFamiTrackerDoc *pDoc)
 		}
 	}
 
-	try {
-		json j = json::parse(jsonparse);
-		pDoc->OptionalJSONToInterface(j);
-	}
-	catch (json::parse_error& e) {
-		sResult.Format(_T("JSON parsing error:\n%s\n\nException ID: %d\nByte position of error: %d\n\nOptional JSON data will be ignored."), e.what(), e.id, e.byte);
+	if (jsonparse.size()) {
+		try {
+			json j = json::parse(jsonparse);
+			pDoc->OptionalJSONToInterface(j);
+		}
+		catch (json::parse_error& e) {
+			sResult.Format(_T("JSON parsing error:\n%s\n\nException ID: %d\nByte position of error: %d\n\nOptional JSON data will be ignored."), e.what(), e.id, e.byte);
+		}
 	}
 
 	if (N163count != -1) {		// // //


### PR DESCRIPTION
This pull request fixes the other (unwanted message box) portion of #168. This should be merged after the redirection fix #180.